### PR TITLE
Fix modern-GCC build: link order and -Werror diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ clean:
 
 tar:
 	rm -f coucal.tgz
-	tar cvfz coucal.tgz coucal.txt coucal.c coucal.h Makefile LICENSE README.md
+	tar cvfz coucal.tgz coucal.c coucal.h murmurhash3.h \
+		sample.c tests.c Makefile LICENSE README.md
 
 gcc:
 	gcc -c -fPIC -O3 -g3 -pthread \
@@ -32,8 +33,8 @@ tests:
 		-D_REENTRANT \
 		tests.c -o tests.o
 	gcc -fPIC -O3 -Wl,-O1 \
-		-lcoucal -L. \
-		tests.o -o tests 
+		tests.o -o tests \
+		-L. -lcoucal
 
 sample:
 	gcc -c -fPIC -O3 -g3 \
@@ -41,8 +42,8 @@ sample:
 		-D_REENTRANT \
 		sample.c -o sample.o
 	gcc -fPIC -O3 -Wl,-O1 \
-		-lcoucal -L. \
-		sample.o -o sample
+		sample.o -o sample \
+		-L. -lcoucal
 
 runtests:
 	LD_LIBRARY_PATH=. ./tests 100000

--- a/coucal.c
+++ b/coucal.c
@@ -601,7 +601,9 @@ static void coucal_compact_pool(coucal hashtable, size_t capacity) {
 /* realloc (expand) string pool ; does not change the compacity */
 static void coucal_realloc_pool(coucal hashtable, size_t capacity) {
   const size_t hash_size = POW2(hashtable->lg_size);
-  char *const oldbase = hashtable->pool.buffer;
+  /* keep the old base as an integer: after realloc() the old pointer value is
+     indeterminate and must not be used in pointer arithmetic (-Wuse-after-free) */
+  const uintptr_t oldbase = (uintptr_t) hashtable->pool.buffer;
   size_t count = 0;
 
   /* we manage the string pool */
@@ -633,7 +635,7 @@ static void coucal_realloc_pool(coucal hashtable, size_t capacity) {
   /* recompute string address */
 #define RECOMPUTE_STRING(S) do {                                     \
     if (S != NULL && S != the_empty_string) {                        \
-      const size_t offset = (const char*) (S) - oldbase;             \
+      const size_t offset = (uintptr_t) (const char*) (S) - oldbase; \
       coucal_assert(hashtable, offset < hashtable->pool.capacity);  \
       S = &hashtable->pool.buffer[offset];                           \
       count++;                                                       \
@@ -641,7 +643,7 @@ static void coucal_realloc_pool(coucal hashtable, size_t capacity) {
 } while(0)
 
   /* recompute string addresses */
-  if (hashtable->pool.buffer != oldbase) {
+  if ((uintptr_t) hashtable->pool.buffer != oldbase) {
     size_t i;
     for(i = 0 ; i < hash_size ; i++) {
       RECOMPUTE_STRING(hashtable->items[i].name);

--- a/murmurhash3.h
+++ b/murmurhash3.h
@@ -91,6 +91,11 @@ static void MurmurHash3_x86_128 ( const void * key, const int len,
   uint32_t k3 = 0;
   uint32_t k4 = 0;
 
+  /* the tail switch deliberately falls through each case */
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
   switch(len & 15)
   {
   case 15: k4 ^= tail[14] << 16;
@@ -116,6 +121,9 @@ static void MurmurHash3_x86_128 ( const void * key, const int len,
   case  1: k1 ^= tail[ 0] << 0;
            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 
   h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;

--- a/tests.c
+++ b/tests.c
@@ -143,7 +143,7 @@ static int coucal_test(const char *snum) {
       size_t i;
       for(i = bench[loop].offset ; i < (size_t) count
           ; i += bench[loop].modulus) {
-        int result;
+        int result = 0;
         char buffer[256];
         const char *name;
         const long expected = (long) i * 1664525 + 1013904223;


### PR DESCRIPTION
coucal stopped building cleanly on a current toolchain (tested on GCC 14.2). Two kinds of problem, both fixed here.

Makefile: the tests and sample targets linked `-lcoucal` before the object files, so modern ld resolved nothing and every coucal_* symbol came up undefined; objects now precede `-L. -lcoucal`. The tar target also referenced a nonexistent coucal.txt, replaced with the files actually shipped.

Compiler diagnostics, now clean under -Werror: the string-pool realloc tripped -Wuse-after-free because it recomputes interior pointers from the old base after realloc; the base is now captured as a uintptr_t beforehand, with behavior unchanged. murmurhash3.h's tail switch falls through on purpose, so it is wrapped in a GCC/clang diagnostic pragma that leaves the public-domain algorithm untouched. tests.c had an uninitialized `result`.

Verified: `make gcc tests sample` builds with no warnings under -Werror, `./tests 100000` passes, and the sample runs.

Follow-up CI and a Makefile rewrite are in #3.