### PR TITLE
Add CI and modernize the Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+# Build and test coucal across compilers, architectures, the 32-bit ABI,
+# sanitizers, and macOS. The library ships as a hand-written Makefile, so CI
+# drives that Makefile directly: it is exactly what rotted unnoticed before
+# (a stale link order made `make` fail on modern toolchains, with no CI to
+# catch it).
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege: the workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch or PR.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build+test (${{ matrix.arch }}, ${{ matrix.cc }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86-64, runner: ubuntu-24.04,     cc: gcc }
+          - { arch: x86-64, runner: ubuntu-24.04,     cc: clang }
+          - { arch: arm64,  runner: ubuntu-24.04-arm, cc: gcc }
+          - { arch: arm64,  runner: ubuntu-24.04-arm, cc: clang }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential clang
+
+      # `make all` builds the static lib, shared lib, tests, and sample under
+      # the chosen compiler; `make check` runs the test suite.
+      - name: Build and test
+        run: make all check CC=${{ matrix.cc }}
+
+  sanitizers:
+    name: sanitizers (asan+ubsan, gcc)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential
+
+      # The hashtable is pointer- and offset-heavy: the string pool realloc()
+      # moves interior key pointers and recomputes them by offset. ASan/UBSan
+      # are the cheapest guard against the use-after-free / out-of-bounds class
+      # of bug on that path. Flags ride in via CFLAGS/LDFLAGS, which the
+      # Makefile appends its mandatory flags onto.
+      - name: Build and run under ASan + UBSan
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+        run: |
+          set -euo pipefail
+          make check \
+            CFLAGS="-O1 -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all" \
+            LDFLAGS="-fsanitize=address -fsanitize=undefined"
+
+  abi32:
+    name: build+test (linux i386, gcc -m32)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install 32-bit toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential gcc-multilib
+
+      # Exercises the 32-bit pointer / size_t ABI, where the string-pool offset
+      # math (the uintptr_t pointer recompute) can truncate or wrap in ways the
+      # 64-bit build never reveals.
+      - name: Build and test (-m32)
+        run: make all check CC="gcc -m32"
+
+  macos:
+    name: build+test (macOS arm64, clang)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      # The Makefile is portable (it switches to a .dylib link on Darwin), so
+      # macOS runs the same `make all check`. This exercises the code on a
+      # second libc/kernel and on Apple clang.
+      - name: Build and test
+        run: make all check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Build artifacts
+*.o
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.exe
+tests
+sample
+coucal.tgz
+
+# Local Claude Code working notes (untracked)
+/CLAUDE.local.md

--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,85 @@
 ###############################################################################
 #
-# "Cuckoo Hashtables"
+# coucal — Cuckoo-hashing hashtable with a stash area
 #
 ###############################################################################
 
-CFILES = coucal.c
+# --- Toolchain (overridable) -------------------------------------------------
+# cc/ar are the POSIX defaults; CI overrides CC with clang or "gcc -m32".
+CC      ?= cc
+AR      ?= ar
+RM      ?= rm -f
+INSTALL ?= install
+PREFIX  ?= /usr/local
 
-all: gcc tests sample runtests
+# --- Flags -------------------------------------------------------------------
+# CFLAGS holds the user-overridable optimization/debug flags. Everything
+# mandatory (PIC, reentrancy, strict warnings, the default hash backend) is
+# appended with `override` so it survives a command-line CFLAGS=... — e.g. CI
+# injecting sanitizer flags.
+CFLAGS  ?= -O3 -g
 
-clean:
-	rm -f *.o *.obj *.so* *.dll *.exe *.pdb *.exp *.lib sample tests
+override CPPFLAGS += -D_REENTRANT -D_GNU_SOURCE -DHTS_INTHASH_USES_MURMUR
+override CFLAGS   += -fPIC -pthread \
+                    -W -Wall -Wextra -Werror -Wno-unused-function
 
-tar:
-	rm -f coucal.tgz
-	tar cvfz coucal.tgz coucal.c coucal.h murmurhash3.h \
+# --- Platform shared-library wiring ------------------------------------------
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  SHLIB   := libcoucal.dylib
+  SOFLAGS := -dynamiclib -install_name @rpath/$(SHLIB)
+  SOLIBS  :=
+else
+  SHLIB   := libcoucal.so
+  SOFLAGS := -shared -Wl,-soname=$(SHLIB) -Wl,--no-undefined
+  SOLIBS  := -ldl -lpthread
+endif
+
+STATICLIB := libcoucal.a
+
+# --- Sources -----------------------------------------------------------------
+LIBSRC := coucal.c
+LIBOBJ := $(LIBSRC:.c=.o)
+BINS   := tests sample
+
+# --- Targets -----------------------------------------------------------------
+.PHONY: all check test clean dist install
+.DEFAULT_GOAL := all
+
+all: $(STATICLIB) $(SHLIB) $(BINS)
+
+# Every object needs the public header; the library object also pulls in the
+# bundled MurmurHash implementation.
+%.o: %.c coucal.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+coucal.o: murmurhash3.h
+
+$(STATICLIB): $(LIBOBJ)
+	$(AR) rcs $@ $^
+
+$(SHLIB): $(LIBOBJ)
+	$(CC) $(CFLAGS) $(SOFLAGS) $(LIBOBJ) -o $@ $(LDFLAGS) $(SOLIBS)
+
+# tests/sample link the static archive: no LD_LIBRARY_PATH, identical run on
+# Linux and macOS.
+tests: tests.o $(STATICLIB)
+	$(CC) $(CFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS)
+sample: sample.o $(STATICLIB)
+	$(CC) $(CFLAGS) $< $(STATICLIB) -o $@ $(LDFLAGS)
+
+check test: tests
+	./tests 100000
+
+install: all
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/lib $(DESTDIR)$(PREFIX)/include
+	$(INSTALL) -m 644 $(STATICLIB) $(DESTDIR)$(PREFIX)/lib/
+	$(INSTALL) -m 755 $(SHLIB)     $(DESTDIR)$(PREFIX)/lib/
+	$(INSTALL) -m 644 coucal.h     $(DESTDIR)$(PREFIX)/include/
+
+dist:
+	$(RM) coucal.tgz
+	tar cvfz coucal.tgz $(LIBSRC) coucal.h murmurhash3.h \
 		sample.c tests.c Makefile LICENSE README.md
 
-gcc:
-	gcc -c -fPIC -O3 -g3 -pthread \
-		-W -Wall -Wextra -Werror -Wno-unused-function \
-		-D_REENTRANT -D_GNU_SOURCE \
-		-DHTS_INTHASH_USES_MURMUR \
-		$(CFILES)
-	gcc -shared -fPIC -O3 -Wl,-O1 -Wl,--no-undefined \
-		-rdynamic -shared -Wl,-soname=libcoucal.so \
-		coucal.o -o libcoucal.so \
-		-ldl -lpthread
-
-tests:
-	gcc -c -fPIC -O3 -g3 \
-		-W -Wall -Wextra -Werror -Wno-unused-function \
-		-D_REENTRANT \
-		tests.c -o tests.o
-	gcc -fPIC -O3 -Wl,-O1 \
-		tests.o -o tests \
-		-L. -lcoucal
-
-sample:
-	gcc -c -fPIC -O3 -g3 \
-		-W -Wall -Wextra -Werror -Wno-unused-function \
-		-D_REENTRANT \
-		sample.c -o sample.o
-	gcc -fPIC -O3 -Wl,-O1 \
-		sample.o -o sample \
-		-L. -lcoucal
-
-runtests:
-	LD_LIBRARY_PATH=. ./tests 100000
+clean:
+	$(RM) *.o $(STATICLIB) $(SHLIB) libcoucal.so.* $(BINS) coucal.tgz

--- a/coucal.c
+++ b/coucal.c
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <assert.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #include "coucal.h"
 
@@ -109,15 +110,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* 64-bit constant */
 #if (defined(WIN32))
 #define UINT_64_CONST(X) ((uint64_t) (X))
-#define UINT_64_FORMAT "I64d"
 #elif (defined(_LP64) || defined(__x86_64__) \
        || defined(__powerpc64__) || defined(__64BIT__))
 #define UINT_64_CONST(X) ((uint64_t) X##UL)
-#define UINT_64_FORMAT "ld"
 #else
 #define UINT_64_CONST(X) ((uint64_t) X##ULL)
-#define UINT_64_FORMAT "lld"
 #endif
+
+/* printf length modifier for uint64_t. The hand-rolled "ld"/"lld" guess broke
+   on LP64 platforms where uint64_t is unsigned long long rather than unsigned
+   long (e.g. Apple arm64), tripping clang -Wformat. PRIu64 matches uint64_t
+   exactly everywhere; all UINT_64_FORMAT arguments are (uint64_t)-cast counts. */
+#define UINT_64_FORMAT PRIu64
 
 /** Hashtable. **/
 struct struct_coucal {

--- a/tests.c
+++ b/tests.c
@@ -101,7 +101,7 @@ static int coucal_test(const char *snum) {
     { DO_DEL, 42, 0 },    /* add 42/0 */
     { TEST_DEL, 42, 0 },  /* check 42/0 */
     { TEST_ADD, 42, 2 },  /* check 42/2 */
-    { DO_END }
+    { DO_END, 0, 0 }
   };
   char *buff = NULL;
   const char **strings = NULL;


### PR DESCRIPTION
Follow-up to #2, which merged before this commit was pushed, so the CI workflow and Makefile rewrite never reached master. This carries them over unchanged.

The Makefile is rewritten to standard form: CC/CFLAGS/CPPFLAGS/LDFLAGS with the mandatory flags override-appended, .PHONY targets, a pattern rule, and Linux/macOS platform detection. It builds a static and a shared library; tests and sample link the static archive, so they run without LD_LIBRARY_PATH and behave the same on both systems. Targets are now all/check/clean/install/dist.

CI builds and tests on gcc and clang across x86-64 and arm64 through that Makefile, then adds an ASan+UBSan run, a 32-bit -m32 build that exercises the pointer-offset math, and a macOS build. It gates the default MurmurHash backend only. The FNV1, OpenSSL-MD5, and 64-bit-hash configs are independently broken and left for a follow-up.

tests.c gets one fix the new clang path needs: the bench[] terminator is fully initialized so -Wextra is clean. A .gitignore covers build artifacts and the local CLAUDE notes file.

Verified locally: every CI configuration builds with no warnings under -Werror and the suite passes, including under ASan/UBSan and in 32-bit.