### PR TITLE
Fix misaligned 32-bit loads in MurmurHash3 (UBSan)

### DIFF
--- a/murmurhash3.h
+++ b/murmurhash3.h
@@ -20,15 +20,20 @@ typedef unsigned __int64 uint64_t;
 #else
 #include <stdint.h>
 #endif
+#include <string.h>
 
 static uint32_t rotl32 ( uint32_t x, int8_t r )
 {
   return (x << r) | (x >> (32 - r));
 }
 #define ROTL32(x,y)     rotl32(x,y)
-static uint32_t getblock32 ( const uint32_t * p, int i )
+static uint32_t getblock32 ( const uint8_t * p, int i )
 {
-  return p[i];
+  /* memcpy the 32-bit block: defined on any alignment, and lowered to the same
+     single load as p[i] on hosts that tolerate unaligned access. */
+  uint32_t v;
+  memcpy(&v, p + (size_t)i * 4, sizeof(v));
+  return v;
 }
 static uint32_t fmix32 ( uint32_t h )
 {
@@ -56,7 +61,7 @@ static void MurmurHash3_x86_128 ( const void * key, const int len,
   const uint32_t c3 = 0x38b34ae5; 
   const uint32_t c4 = 0xa1e38b93;
 
-  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+  const uint8_t * blocks = data + nblocks*16;
   int i;
   
   for(i = -nblocks; i; i++)

--- a/murmurhash3.h.diff
+++ b/murmurhash3.h.diff
@@ -1,6 +1,6 @@
---- murmurhash3.h.orig	2014-06-14 14:29:11.562576736 +0200
-+++ murmurhash3.h	2014-06-14 14:39:43.989624584 +0200
-@@ -7,7 +7,19 @@
+--- murmurhash3.h.orig	2015-03-15 15:22:27.882839226 +0100
++++ murmurhash3.h	2026-06-14 23:15:26.024117389 +0200
+@@ -7,16 +7,33 @@
  // compile and run any of them on any platform, but your performance with the
  // non-native version will be less than optimal.
  
@@ -17,6 +17,53 @@
 +#else
  #include <stdint.h>
 +#endif
++#include <string.h>
  
  static uint32_t rotl32 ( uint32_t x, int8_t r )
  {
+   return (x << r) | (x >> (32 - r));
+ }
+ #define ROTL32(x,y)     rotl32(x,y)
+-static uint32_t getblock32 ( const uint32_t * p, int i )
++static uint32_t getblock32 ( const uint8_t * p, int i )
+ {
+-  return p[i];
++  /* memcpy the 32-bit block: defined on any alignment, and lowered to the same
++     single load as p[i] on hosts that tolerate unaligned access. */
++  uint32_t v;
++  memcpy(&v, p + (size_t)i * 4, sizeof(v));
++  return v;
+ }
+ static uint32_t fmix32 ( uint32_t h )
+ {
+@@ -44,7 +61,7 @@
+   const uint32_t c3 = 0x38b34ae5; 
+   const uint32_t c4 = 0xa1e38b93;
+ 
+-  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
++  const uint8_t * blocks = data + nblocks*16;
+   int i;
+   
+   for(i = -nblocks; i; i++)
+@@ -79,6 +96,11 @@
+   uint32_t k3 = 0;
+   uint32_t k4 = 0;
+ 
++  /* the tail switch deliberately falls through each case */
++#if defined(__GNUC__) || defined(__clang__)
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
++#endif
+   switch(len & 15)
+   {
+   case 15: k4 ^= tail[14] << 16;
+@@ -104,6 +126,9 @@
+   case  1: k1 ^= tail[ 0] << 0;
+            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+   };
++#if defined(__GNUC__) || defined(__clang__)
++#pragma GCC diagnostic pop
++#endif
+ 
+ 
+   h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;


### PR DESCRIPTION
getblock32 read the key 32 bits at a time by casting the arbitrary byte key to const uint32_t* and dereferencing it. That is undefined behaviour whenever the address is not 4-byte aligned, which is the common case for string keys, so UBSan's alignment check fires on essentially every coucal insert and lookup. It is harmless on x86-64 and arm64 (both tolerate unaligned loads) but a genuine portability and strict-alignment hazard, and the compiler is free to assume the pointer is aligned.

The fix reads each block with memcpy on a uint8_t*, dropping the uint32_t* casts at both getblock32 and its call site. The compiler lowers the 4-byte memcpy to the same single load on x86/arm, so there is no performance cost, and the result is well-defined everywhere. MurmurHash3 is defined for little-endian input and the old p[i] already produced host-endian values, so hash output is byte-for-byte unchanged on the little-endian hosts coucal runs on.

murmurhash3.h.diff is regenerated to match; it had also drifted from the earlier fallthrough-pragma change.

Verified clean under -fsanitize=address,undefined -fno-sanitize-recover=all: tests 100000 passes with no misaligned-load report, and the default -Werror build is unaffected.

Found during ASan+UBSan CI bring-up for httrack, where coucal is vendored at src/coucal. Once the submodule pointer is bumped there, the httrack ASan/UBSan job can drop the -fno-sanitize=alignment mask it currently carries for this one finding.