### PR TITLE
Widen MurmurHash3 tail bytes to uint32_t (fix signed-shift UB)

### DIFF
--- a/murmurhash3.h
+++ b/murmurhash3.h
@@ -96,34 +96,35 @@ static void MurmurHash3_x86_128 ( const void * key, const int len,
   uint32_t k3 = 0;
   uint32_t k4 = 0;
 
-  /* the tail switch deliberately falls through each case */
+  /* deliberate fall-through; widen each byte to uint32_t so a high byte shifted
+     left 24 can't overflow signed int (UBSan) */
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
   switch(len & 15)
   {
-  case 15: k4 ^= tail[14] << 16;
-  case 14: k4 ^= tail[13] << 8;
-  case 13: k4 ^= tail[12] << 0;
+  case 15: k4 ^= (uint32_t)tail[14] << 16;
+  case 14: k4 ^= (uint32_t)tail[13] << 8;
+  case 13: k4 ^= (uint32_t)tail[12] << 0;
            k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
 
-  case 12: k3 ^= tail[11] << 24;
-  case 11: k3 ^= tail[10] << 16;
-  case 10: k3 ^= tail[ 9] << 8;
-  case  9: k3 ^= tail[ 8] << 0;
+  case 12: k3 ^= (uint32_t)tail[11] << 24;
+  case 11: k3 ^= (uint32_t)tail[10] << 16;
+  case 10: k3 ^= (uint32_t)tail[ 9] << 8;
+  case  9: k3 ^= (uint32_t)tail[ 8] << 0;
            k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
 
-  case  8: k2 ^= tail[ 7] << 24;
-  case  7: k2 ^= tail[ 6] << 16;
-  case  6: k2 ^= tail[ 5] << 8;
-  case  5: k2 ^= tail[ 4] << 0;
+  case  8: k2 ^= (uint32_t)tail[ 7] << 24;
+  case  7: k2 ^= (uint32_t)tail[ 6] << 16;
+  case  6: k2 ^= (uint32_t)tail[ 5] << 8;
+  case  5: k2 ^= (uint32_t)tail[ 4] << 0;
            k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
 
-  case  4: k1 ^= tail[ 3] << 24;
-  case  3: k1 ^= tail[ 2] << 16;
-  case  2: k1 ^= tail[ 1] << 8;
-  case  1: k1 ^= tail[ 0] << 0;
+  case  4: k1 ^= (uint32_t)tail[ 3] << 24;
+  case  3: k1 ^= (uint32_t)tail[ 2] << 16;
+  case  2: k1 ^= (uint32_t)tail[ 1] << 8;
+  case  1: k1 ^= (uint32_t)tail[ 0] << 0;
            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
 #if defined(__GNUC__) || defined(__clang__)

--- a/murmurhash3.h.diff
+++ b/murmurhash3.h.diff
@@ -1,5 +1,5 @@
---- murmurhash3.h.orig	2015-03-15 15:22:27.882839226 +0100
-+++ murmurhash3.h	2026-06-14 23:15:26.024117389 +0200
+--- murmurhash3.h.orig
++++ murmurhash3.h
 @@ -7,16 +7,33 @@
  // compile and run any of them on any platform, but your performance with the
  // non-native version will be less than optimal.
@@ -45,20 +45,54 @@
    int i;
    
    for(i = -nblocks; i; i++)
-@@ -79,6 +96,11 @@
+@@ -79,31 +96,40 @@
    uint32_t k3 = 0;
    uint32_t k4 = 0;
  
-+  /* the tail switch deliberately falls through each case */
++  /* deliberate fall-through; widen each byte to uint32_t so a high byte shifted
++     left 24 can't overflow signed int (UBSan) */
 +#if defined(__GNUC__) || defined(__clang__)
 +#pragma GCC diagnostic push
 +#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 +#endif
    switch(len & 15)
    {
-   case 15: k4 ^= tail[14] << 16;
-@@ -104,6 +126,9 @@
-   case  1: k1 ^= tail[ 0] << 0;
+-  case 15: k4 ^= tail[14] << 16;
+-  case 14: k4 ^= tail[13] << 8;
+-  case 13: k4 ^= tail[12] << 0;
++  case 15: k4 ^= (uint32_t)tail[14] << 16;
++  case 14: k4 ^= (uint32_t)tail[13] << 8;
++  case 13: k4 ^= (uint32_t)tail[12] << 0;
+            k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+ 
+-  case 12: k3 ^= tail[11] << 24;
+-  case 11: k3 ^= tail[10] << 16;
+-  case 10: k3 ^= tail[ 9] << 8;
+-  case  9: k3 ^= tail[ 8] << 0;
++  case 12: k3 ^= (uint32_t)tail[11] << 24;
++  case 11: k3 ^= (uint32_t)tail[10] << 16;
++  case 10: k3 ^= (uint32_t)tail[ 9] << 8;
++  case  9: k3 ^= (uint32_t)tail[ 8] << 0;
+            k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+ 
+-  case  8: k2 ^= tail[ 7] << 24;
+-  case  7: k2 ^= tail[ 6] << 16;
+-  case  6: k2 ^= tail[ 5] << 8;
+-  case  5: k2 ^= tail[ 4] << 0;
++  case  8: k2 ^= (uint32_t)tail[ 7] << 24;
++  case  7: k2 ^= (uint32_t)tail[ 6] << 16;
++  case  6: k2 ^= (uint32_t)tail[ 5] << 8;
++  case  5: k2 ^= (uint32_t)tail[ 4] << 0;
+            k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+ 
+-  case  4: k1 ^= tail[ 3] << 24;
+-  case  3: k1 ^= tail[ 2] << 16;
+-  case  2: k1 ^= tail[ 1] << 8;
+-  case  1: k1 ^= tail[ 0] << 0;
++  case  4: k1 ^= (uint32_t)tail[ 3] << 24;
++  case  3: k1 ^= (uint32_t)tail[ 2] << 16;
++  case  2: k1 ^= (uint32_t)tail[ 1] << 8;
++  case  1: k1 ^= (uint32_t)tail[ 0] << 0;
             k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
    };
 +#if defined(__GNUC__) || defined(__clang__)

--- a/tests.c
+++ b/tests.c
@@ -215,7 +215,37 @@ static int coucal_test(const char *snum) {
   }
 }
 
+/* Regression for the MurmurHash3 tail UB: a key byte landing in a "<< 24" slot
+   with the high bit set used to overflow signed int (UBSan). Lengths 4/8/12 put
+   that byte last; hash and read each back so a sanitized run guards the fix. */
+static int coucal_test_high_bytes(void) {
+  static const char *const keys[] = {
+    "abc\xC3",        /* len 4  -> tail[3]  << 24 */
+    "abcdefg\xC3",    /* len 8  -> tail[7]  << 24 */
+    "abcdefghijk\xC3" /* len 12 -> tail[11] << 24 */
+  };
+  coucal hashtable = coucal_new(0);
+  size_t i;
+  for(i = 0 ; i < sizeof(keys)/sizeof(keys[0]) ; i++) {
+    coucal_write(hashtable, keys[i], (uintptr_t) (i + 1));
+  }
+  for(i = 0 ; i < sizeof(keys)/sizeof(keys[0]) ; i++) {
+    intptr_t value = -1;
+    if (!coucal_readptr(hashtable, keys[i], &value)
+        || value != (intptr_t) (i + 1)) {
+      fprintf(stderr, "high-byte key %lu failed\n", (unsigned long) i);
+      coucal_delete(&hashtable);
+      return EXIT_FAILURE;
+    }
+  }
+  coucal_delete(&hashtable);
+  return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
+  if (coucal_test_high_bytes() != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
   if (argc == 2) {
     return coucal_test(argv[1]);
   } else {


### PR DESCRIPTION
In the MurmurHash3 tail switch a byte promotes to `int`, so `tail[n] << 24` overflows signed `int` once the byte has its high bit set (e.g. `0xC3 << 24`). UBSan reports it as `left shift ... cannot be represented in type 'int'`. It showed up running a live HTTrack crawl through ASan+UBSan: the cache hashmap hashes arbitrary URL keys, and one with the right tail byte aborted the crawl. The existing `./tests` suite uses decimal-integer keys (all bytes < 0x80), so it never tripped.

Fix: cast each tail byte to `uint32_t` before the shift. The value already accumulates into a `uint32_t`, so the hash output is bit-identical; this only removes the UB.

Added a `tests.c` regression that hashes keys of length 4/8/12 whose high byte lands in a `<< 24` slot. Reverting the cast makes that test abort under `-fno-sanitize-recover` at `murmurhash3.h:123`, so it actually guards the fix. Verified clean under the ASan/UBSan and the default `-Werror` builds; `murmurhash3.h.diff` regenerated and round-trips against `.orig`.